### PR TITLE
Add support for force caching requests

### DIFF
--- a/Example/NetworkingServiceKit/TwitterAPIConfiguration.swift
+++ b/Example/NetworkingServiceKit/TwitterAPIConfiguration.swift
@@ -81,13 +81,8 @@ public enum TwitterAPIConfigurationType: String, APIConfigurationType {
         return self.rawValue.capitalized
     }
 
-    /// Explicitly tells our protocol which is our staging configuration
-    public static var stagingConfiguration: APIConfigurationType {
-        return TwitterAPIConfigurationType.staging
-    }
-
-    /// Explicitly tells our protocol which is our production configuration
-    public static var productionConfiguration: APIConfigurationType {
+    /// Explicitly tells our protocol which is our default configuration
+    public static var defaultConfiguration: APIConfigurationType {
         return TwitterAPIConfigurationType.production
     }
 }

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Alamofire (4.4.0)
+  - Alamofire (4.5.0)
   - AlamofireImage (3.2.0):
     - Alamofire (~> 4.1)
   - CryptoSwift (0.6.9)
@@ -10,7 +10,7 @@ PODS:
     - URITemplate (~> 2.0)
   - Mockingjay/XCTest (2.0.0):
     - Mockingjay/Core
-  - NetworkingServiceKit (0.8.1):
+  - NetworkingServiceKit (0.9.0):
     - Alamofire
     - AlamofireImage
     - CryptoSwift
@@ -31,11 +31,11 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  Alamofire: dc44b1600b800eb63da6a19039a0083d62a6a62d
+  Alamofire: f28cdffd29de33a7bfa022cbd63ae95a27fae140
   AlamofireImage: 157ed682cc81d3b9db4fb90c1f12180ac552d93b
   CryptoSwift: a22f6ba238e9ce4d26ee7bf45b9ed82e7122d4a0
   Mockingjay: 7122a3fc0597aa63438e4cd9b71b7bc8aac05b87
-  NetworkingServiceKit: ec00e7817f4439c0d328c06f8bee4306d4d984e1
+  NetworkingServiceKit: 80b51f76005df76715da712849ffb3140fcec446
   Nimble: 415e3aa3267e7bc2c96b05fa814ddea7bb686a29
   Quick: 8024e4a47e6cc03a9d5245ef0948264fc6d27cff
   SwiftyJSON: c2842d878f95482ffceec5709abc3d05680c0220

--- a/Example/Tests/AlamoNetworkManagerTests.swift
+++ b/Example/Tests/AlamoNetworkManagerTests.swift
@@ -12,6 +12,34 @@ import Nimble
 import NetworkingServiceKit
 import Mockingjay
 
+public enum RandomConfigurationType: String, APIConfigurationType {
+    case basic = "BASIC"
+
+    public init(stringKey: String) {
+        self = .basic
+    }
+    
+    /// URL for given server
+    public var URL: String {
+        return "https://random.com"
+    }
+    
+    /// Web URL for given server
+    public var webURL: String {
+        return "https://random.com"
+    }
+    
+    /// Display name for given server
+    public var displayName: String {
+        return self.rawValue.capitalized
+    }
+    
+    /// Explicitly tells our protocol which is our default configuration
+    public static var defaultConfiguration: APIConfigurationType {
+        return RandomConfigurationType.basic
+    }
+}
+
 class RandomService : AbstractBaseService {
     override var serviceVersion: String {
         return "v3"
@@ -27,9 +55,10 @@ class AlamoNetworkManagerTests: QuickSpec
         let dictionaryNextResponse4 = ["results" : [["obj3" : "value"]]] as [String : Any]
         
         beforeEach {
+            MockingjayProtocol.removeAllStubs()
             ServiceLocator.defaultNetworkClientType = AlamoNetworkManager.self
             ServiceLocator.set(services: [RandomService.self],
-                               api: TwitterAPIConfigurationType.self,
+                               api: RandomConfigurationType.self,
                                auth: TwitterApp.self,
                                token: TwitterAPIToken.self)
         }
@@ -168,6 +197,102 @@ class AlamoNetworkManagerTests: QuickSpec
                             }
                         })
                     }
+                }
+            }
+            
+            context("that is force cached") {
+                it("should correctly store and return the cached request if the cache is valid") {
+                    MockingjayProtocol.addStub(matcher: http(.get, uri: "/v3/dictionary"), builder: json(dictionaryResponse))
+                    
+                    waitUntil { done in
+                        let randomService = ServiceLocator.service(forType: RandomService.self)
+                        randomService?.request(path: "dictionary", cachePolicy:CacheResponsePolicy(type: .forceCache, maxAge: 2),
+                                               success: { response in
+                            expect(response).toNot(beNil())
+                            let originalRequest = URLRequest(url: URL(string: "https://random.com/v3/dictionary")!)
+                            let cachedResponse = originalRequest.cachedJSONResponse()
+                            expect(cachedResponse).toNot(beNil())
+                                                
+                            //Since we are cache now, the stubs should not be needed
+                            MockingjayProtocol.removeAllStubs()
+                            randomService?.request(path: "dictionary", cachePolicy:CacheResponsePolicy(type: .forceCache, maxAge: 2),
+                                                   success: { response in
+                                expect(response).toNot(beNil())
+                                done()
+                            }, failure: { error, errorDetails in
+                            })
+                        }, failure: { error, errorDetails in
+                        })
+                    }
+                }
+                
+                it("should fail if the cache has been invalidated") {
+                    MockingjayProtocol.addStub(matcher: http(.get, uri: "/v3/dictionary"), builder: json(dictionaryResponse))
+                    
+                    waitUntil(timeout:6) { done in
+                        let randomService = ServiceLocator.service(forType: RandomService.self)
+                        randomService?.request(path: "dictionary", cachePolicy:CacheResponsePolicy(type: .forceCache, maxAge: 2),
+                                               success: { response in
+                                                expect(response).toNot(beNil())
+                                                let originalRequest = URLRequest(url: URL(string: "https://random.com/v3/dictionary")!)
+                                                let cachedResponse = originalRequest.cachedJSONResponse()
+                                                expect(cachedResponse).toNot(beNil())
+                                                
+                                                //Since we are cache now, the stubs should not be needed
+                                                MockingjayProtocol.removeAllStubs()
+                                                // Now let's wait for the cache to get invalidated
+                                                sleep(3)
+                                                randomService?.request(path: "dictionary", cachePolicy:CacheResponsePolicy(type: .forceCache, maxAge: 2),
+                                                                       success: { response in
+                                                }, failure: { error, errorDetails in
+                                                    //the request to network fails since there is no stub and no cache
+                                                    done()
+                                                })
+                        }, failure: { error, errorDetails in
+                        })
+                    }
+                }
+                
+                it("should correctly return cached responses from paginated requests") {
+                    MockingjayProtocol.addStub(matcher: http(.get, uri: "/v3/dictionary_next1"), builder: json(dictionaryNextResponse2))
+                    MockingjayProtocol.addStub(matcher: http(.get, uri: "/v3/dictionary_next2"), builder: json(dictionaryNextResponse3))
+                    MockingjayProtocol.addStub(matcher: http(.get, uri: "/v3/dictionary_next3"), builder: json(dictionaryNextResponse4))
+                    
+                    waitUntil { done in
+                        let randomService = ServiceLocator.service(forType: RandomService.self)
+                        randomService?.request(path: "dictionary_next1",
+                                               paginated:true,
+                                               cachePolicy:CacheResponsePolicy(type: .forceCache, maxAge: 2),
+                                               success: { response in
+                            expect(response["results"]).toNot(beNil())
+                            let results = response["results"] as! [[String:Any]]
+                            expect(results.count).to(equal(3))
+                                                
+                            let originalRequest1 = URLRequest(url: URL(string: "https://random.com/v3/dictionary_next1")!)
+                            expect(originalRequest1.cachedJSONResponse()).toNot(beNil())
+                            let originalRequest2 = URLRequest(url: URL(string: "https://random.com/v3/dictionary_next2")!)
+                            expect(originalRequest2.cachedJSONResponse()).toNot(beNil())
+                            let originalRequest3 = URLRequest(url: URL(string: "https://random.com/v3/dictionary_next3")!)
+                            expect(originalRequest3.cachedJSONResponse()).toNot(beNil())
+                                                
+                            //Since we are cache now, the stubs should not be needed
+                            MockingjayProtocol.removeAllStubs()
+                                                
+                            //paginated request should work through cache
+                            randomService?.request(path: "dictionary_next1",
+                                                   paginated:true,
+                                                   cachePolicy:CacheResponsePolicy(type: .forceCache, maxAge: 2),
+                                                   success: { response in
+                                expect(response["results"]).toNot(beNil())
+                                let results = response["results"] as! [[String:Any]]
+                                expect(results.count).to(equal(3))
+                                done()
+                            }, failure: { error, errorDetails in
+                            })
+                        }, failure: { error, errorDetails in
+                        })
+                    }
+
                 }
             }
         }

--- a/NetworkingServiceKit.podspec
+++ b/NetworkingServiceKit.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'NetworkingServiceKit'
-  s.version          = '0.8.3'
+  s.version          = '0.9.0'
   s.summary          = 'A service layer of networking microservices for iOS.'
 
 # This description is used to generate tags and improve search results.

--- a/NetworkingServiceKit/Classes/Extensions/HTTPURLResponseExtensions.swift
+++ b/NetworkingServiceKit/Classes/Extensions/HTTPURLResponseExtensions.swift
@@ -1,0 +1,23 @@
+//
+//  HTTPURLResponseExtensions.swift
+//  Pods
+//
+//  Created by Phillipe Casorla Sagot on 7/12/17.
+//
+//
+
+import Foundation
+
+extension HTTPURLResponse {
+    
+    /// By default our URLSessionConfiguration uses NSURLRequest.CachePolicy.useProtocolCachePolicy
+    /// this means our policy for caching requests is interpreted according to the "Cache-Control" header field in the response.
+    /// This property indicates if the response has no cache policy
+    internal var isResponseCachePolicyDisabled:Bool {
+        let responseHeaders = self.allHeaderFields
+        if let cacheControl = responseHeaders["Cache-Control"] as? String {
+            return cacheControl.contains("no-cache") || cacheControl.contains("max-age=0")
+        }
+        return false
+    }
+}

--- a/NetworkingServiceKit/Classes/Extensions/HTTPURLResponseExtensions.swift
+++ b/NetworkingServiceKit/Classes/Extensions/HTTPURLResponseExtensions.swift
@@ -17,6 +17,8 @@ extension HTTPURLResponse {
         let responseHeaders = self.allHeaderFields
         if let cacheControl = responseHeaders["Cache-Control"] as? String {
             return cacheControl.contains("no-cache") || cacheControl.contains("max-age=0")
+        } else if responseHeaders["Cache-Control"] == nil {
+            return true
         }
         return false
     }

--- a/NetworkingServiceKit/Classes/Extensions/URLRequestExtensions.swift
+++ b/NetworkingServiceKit/Classes/Extensions/URLRequestExtensions.swift
@@ -13,7 +13,7 @@ extension URLRequest {
     /// Returns a cached JSON response for the the current request if we have stored it before and it hasn't expired
     ///
     /// - Returns: the cached JSON response
-    internal func cachedJSONResponse() -> Any? {
+    public func cachedJSONResponse() -> Any? {
         if let cachedResponse = URLCache.shared.cachedResponse(for: self),
             let userInfo = cachedResponse.userInfo,
             let startTime = userInfo[CachedURLResponse.CacheURLResponseTime] as? Double,

--- a/NetworkingServiceKit/Classes/Extensions/URLRequestExtensions.swift
+++ b/NetworkingServiceKit/Classes/Extensions/URLRequestExtensions.swift
@@ -14,19 +14,17 @@ extension URLRequest {
     ///
     /// - Returns: the cached JSON response
     public func cachedJSONResponse() -> Any? {
-        if let cachedResponse = URLCache.shared.cachedResponse(for: self),
+        guard let cachedResponse = URLCache.shared.cachedResponse(for: self),
             let userInfo = cachedResponse.userInfo,
             let startTime = userInfo[CachedURLResponse.CacheURLResponseTime] as? Double,
-            let maxAge = userInfo[CachedURLResponse.CacheURLResponseMaxAge] as? Double {
-            let elapsed = CFAbsoluteTimeGetCurrent() - startTime
-            
-            guard elapsed <= maxAge else { return nil }
-            
-            let data = cachedResponse.data
-            let json = try? JSONSerialization.jsonObject(with: data, options: .allowFragments)
-            return json
+            let maxAge = userInfo[CachedURLResponse.CacheURLResponseMaxAge] as? Double,
+            CFAbsoluteTimeGetCurrent() - startTime <= maxAge else {
+                return nil
         }
-        return nil
+        
+        let data = cachedResponse.data
+        let json = try? JSONSerialization.jsonObject(with: data, options: .allowFragments)
+        return json
     }
 }
 

--- a/NetworkingServiceKit/Classes/Extensions/URLRequestExtensions.swift
+++ b/NetworkingServiceKit/Classes/Extensions/URLRequestExtensions.swift
@@ -1,0 +1,53 @@
+//
+//  URLRequestExtensions.swift
+//  Pods
+//
+//  Created by Phillipe Casorla Sagot on 7/12/17.
+//
+//
+
+import Foundation
+
+extension URLRequest {
+    
+    /// Returns a cached JSON response for the the current request if we have stored it before and it hasn't expired
+    ///
+    /// - Returns: the cached JSON response
+    internal func cachedJSONResponse() -> Any? {
+        if let cachedResponse = URLCache.shared.cachedResponse(for: self),
+            let userInfo = cachedResponse.userInfo,
+            let startTime = userInfo[CachedURLResponse.CacheURLResponseTime] as? Double,
+            let maxAge = userInfo[CachedURLResponse.CacheURLResponseMaxAge] as? Double {
+            let elapsed = CFAbsoluteTimeGetCurrent() - startTime
+            
+            guard elapsed <= maxAge else { return nil }
+            
+            let data = cachedResponse.data
+            let json = try? JSONSerialization.jsonObject(with: data, options: .allowFragments)
+            return json
+        }
+        return nil
+    }
+}
+
+extension CachedURLResponse {
+    
+    internal static let CacheURLResponseMaxAge = "maxAge"
+    internal static let CacheURLResponseTime = "time"
+    
+    
+    /// Creates a CachedURLResponse with attached information for maxAge and current time the response got saved
+    ///
+    /// - Parameters:
+    ///   - response: a network responwe
+    ///   - data: response's data
+    ///   - maxAge: max age the response will be valid before expiring
+    internal convenience init(response: URLResponse, data: Data, maxAge:Double) {
+        self.init(response: response,
+                  data: data,
+                  userInfo: [
+                    CachedURLResponse.CacheURLResponseTime : CFAbsoluteTimeGetCurrent(),
+                    CachedURLResponse.CacheURLResponseMaxAge : maxAge],
+                  storagePolicy: .allowed)
+    }
+}

--- a/NetworkingServiceKit/Classes/Networking/APIConfigurations.swift
+++ b/NetworkingServiceKit/Classes/Networking/APIConfigurations.swift
@@ -21,8 +21,7 @@ public protocol APIConfigurationAuth {
 public protocol APIConfigurationType {
     var URL: String { get }
     var webURL: String { get }
-    static var stagingConfiguration: APIConfigurationType { get }
-    static var productionConfiguration: APIConfigurationType { get }
+    static var defaultConfiguration: APIConfigurationType { get }
     init(stringKey: String)
 }
 
@@ -64,10 +63,6 @@ public class APIConfiguration: NSObject {
             return configuration.init(stringKey: environmentConfiguration)
         }
         
-        #if DEBUG || STAGING
-            return configuration.stagingConfiguration
-        #else
-            return configuration.productionConfiguration
-        #endif
+        return configuration.defaultConfiguration
     }
 }

--- a/NetworkingServiceKit/Classes/Networking/AlamoNetworkManager.swift
+++ b/NetworkingServiceKit/Classes/Networking/AlamoNetworkManager.swift
@@ -12,24 +12,31 @@ import Alamofire
 open class AlamoNetworkManager: NetworkManager {
     private static let validStatusCodes = (200...299)
     public var configuration: APIConfiguration
-
+    
     required public init(with configuration: APIConfiguration) {
         self.configuration = configuration
     }
-
+    
     /// default session manager to be use with Alamofire
     private let sessionManager: SessionManager = {
         let sessionConfiguration = URLSessionConfiguration.default
         sessionConfiguration.httpAdditionalHeaders = SessionManager.defaultHTTPHeaders
         sessionConfiguration.httpShouldSetCookies = false
+        //Setup our cache
+        let capacity = 100 * 1024 * 1024 // 100 MBs
+        let urlCache = URLCache(memoryCapacity: capacity, diskCapacity: capacity, diskPath: nil)
+        sessionConfiguration.urlCache = urlCache
+        //This is the default value but let's make it clear caching by default depends on the response Cache-Control header
+        sessionConfiguration.requestCachePolicy = URLRequest.CachePolicy.useProtocolCachePolicy
         let session = SessionManager(configuration: sessionConfiguration)
+        session.startRequestsImmediately = false
         //custom adapter for inserting our authentication
         session.adapter = AlamoAuthenticationAdapter()
         return session
     }()
-
+    
     // MARK: - Request handling
-
+    
     /// Creates and executes a request using Alamofire
     ///
     /// - Parameters:
@@ -37,73 +44,85 @@ open class AlamoNetworkManager: NetworkManager {
     ///   - method: HTTP method, default is GET
     ///   - parameters: URL or body parameters depending on the HTTP method, default is empty
     ///   - paginated: if the request should follow pagination, success only if all pages are completed
+    ///   - cachePolicy: specifices the policy to follow for caching responses
     ///   - headers: custom headers that should be attached with this request
     ///   - success: success block with a response
     ///   - failure: failure block with an error
     public func request(path: String,
-                 method: NetworkingServiceKit.HTTPMethod = .get,
-                 with parameters: RequestParameters = RequestParameters(),
-                 paginated: Bool = false,
-                 headers: CustomHTTPHeaders = CustomHTTPHeaders(),
-                 stubs: [ServiceStub],
-                 success: @escaping SuccessResponseBlock,
-                 failure: @escaping ErrorResponseBlock) {
-
+                        method: NetworkingServiceKit.HTTPMethod = .get,
+                        with parameters: RequestParameters = RequestParameters(),
+                        paginated: Bool = false,
+                        cachePolicy:CacheResponsePolicy,
+                        headers: CustomHTTPHeaders = CustomHTTPHeaders(),
+                        stubs: [ServiceStub],
+                        success: @escaping SuccessResponseBlock,
+                        failure: @escaping ErrorResponseBlock) {
+        
         guard let httpMethod = Alamofire.HTTPMethod(rawValue: method.string) else { return }
-
+        
         //lets use URL encoding only for GETs / DELETEs OR use a specific encoding for arrays
         var encoding: ParameterEncoding = method == .get || method == .delete ? URLEncoding.default : JSONEncoding.default
         encoding = parameters.validArrayRequest() ? ArrayEncoding() : encoding
         encoding = parameters.validStringRequest() ? StringEncoding() : encoding
         
         let request = sessionManager.request(path,
-                          method: httpMethod,
-                          parameters: parameters,
-                          encoding: encoding,
-                          headers: headers).validate(statusCode: AlamoNetworkManager.validStatusCodes).responseJSON { rawResponse in
-                            //Print response if we have a verbose log mode
-                            if ServiceLocator.logLevel == .verbose {
-                                print("🔵 ServiceLocator: ")
-                                debugPrint(rawResponse)
-                            }
-
-                            if let response = rawResponse.value as? [Any] {
-                                let responseDic = ["results": response]
-                                success(responseDic)
-                            } else if let response = rawResponse.value as? [String:Any],
-                                rawResponse.error == nil {
-                                if let nextPage = response["next"] as? String,
-                                    paginated {
-                                    //call a request with the next page
-                                    self.getNextPage(forURL: nextPage,
-                                                     method: httpMethod,
-                                                     with: parameters,
-                                                     onExistingResponse: response,
-                                                     encoding: encoding,
-                                                     headers: headers,
-                                                     success: success,
-                                                     failure: failure)
-                                } else {
-                                    //return inmediatly
-                                    success(response)
-                                }
-                            } else if let (reason, errorDetails) = self.buildError(fromResponse: rawResponse) {
-                                //Figure out if we have an error and an error response
-                                failure(MSError.responseValidationFailed(reason: reason), errorDetails)
-                            } else {
-                                //if the request is succesful but has no response (validation for http code has passed also)
-                                success([String: Any]())
-                            }
+                                             method: httpMethod,
+                                             parameters: parameters,
+                                             encoding: encoding,
+                                             headers: headers).validate(statusCode: AlamoNetworkManager.validStatusCodes).responseJSON { rawResponse in
+                                                
+                                                //Print response if we have a verbose log mode
+                                                AlamoNetworkManager.logNetwork(rawResponse: rawResponse)
+                                                
+                                                //Return valid response
+                                                if rawResponse.error == nil {
+                                                    // Cached our response through URLCache
+                                                    AlamoNetworkManager.cache(response: rawResponse.response,
+                                                                              with: rawResponse.data,
+                                                                              for: rawResponse.request,
+                                                                              using: cachePolicy)
+                                                    // Process valid response
+                                                    self.process(rawResponse: rawResponse.value,
+                                                                 method: httpMethod,
+                                                                 parameters: parameters,
+                                                                 encoding: encoding,
+                                                                 paginated: paginated,
+                                                                 cachePolicy: cachePolicy,
+                                                                 headers: headers,
+                                                                 success: success,
+                                                                 failure: failure)
+                                                } else if let (reason, errorDetails) = self.buildError(fromResponse: rawResponse) {
+                                                    //Figure out if we have an error and an error response
+                                                    failure(MSError.responseValidationFailed(reason: reason), errorDetails)
+                                                } else {
+                                                    //if the request is succesful but has no response (validation for http code has passed also)
+                                                    success([String: Any]())
+                                                }
         }
-        
-        //Print request if we have log mode enabled
-        if ServiceLocator.logLevel != .none {
-            print("🔵 ServiceLocator: " + request.description)
+
+        if cachePolicy.type == .forceCache,
+            let urlRequest = request.request,
+            let cachedResponse = urlRequest.cachedJSONResponse() {
+            //Process valid response
+            self.process(rawResponse: cachedResponse,
+                         method: httpMethod,
+                         parameters: parameters,
+                         encoding: encoding,
+                         paginated: paginated,
+                         cachePolicy: cachePolicy,
+                         headers: headers,
+                         success: success,
+                         failure: failure)
+            AlamoNetworkManager.log("CACHED \(request.description)")
+        } else {
+            request.resume()
+            AlamoNetworkManager.log(request.description)
         }
     }
-
+    
+    
     // MARK: - Pagination
-
+    
     /// Request the next page, indicated in the response from the first request
     ///
     /// - Parameters:
@@ -113,6 +132,7 @@ open class AlamoNetworkManager: NetworkManager {
     ///   - aggregateResponse: existing response from first call
     ///   - encoding: encoding for the request
     ///   - headers:  headers for the request
+    ///   - cachePolicy: specifices the policy to follow for caching responses
     ///   - success: success block with a response
     ///   - failure: failure block with an error
     func getNextPage(forURL urlString: String,
@@ -121,47 +141,171 @@ open class AlamoNetworkManager: NetworkManager {
                      onExistingResponse aggregateResponse: [String: Any],
                      encoding: ParameterEncoding = URLEncoding.default,
                      headers: CustomHTTPHeaders? = nil,
+                     cachePolicy:CacheResponsePolicy,
                      success: @escaping SuccessResponseBlock,
                      failure: @escaping ErrorResponseBlock) {
-        sessionManager.request(urlString,
-                               method: method,
-                               parameters: parameters,
-                               encoding: encoding,
-                               headers: headers).validate(statusCode: AlamoNetworkManager.validStatusCodes).responseJSON { rawResponse in
-
-                                if let response = rawResponse.value as? [String:Any],
-                                    rawResponse.error == nil {
-                                    var currentResponse = aggregateResponse
-
-                                    //attach new response into existing response
-                                    if var currentResults = currentResponse["results"] as? [[String: Any]],
-                                        let newResults = response["results"] as? [[String : Any]] {
-                                        currentResults.append(contentsOf: newResults)
-                                        currentResponse["results"] = currentResults
-                                    }
-
-                                    //iterate on the next page if any
-                                    if let nextPage = response["next"] as? String,
-                                        !nextPage.isEmpty {
-                                        self.getNextPage(forURL: nextPage,
-                                                         method: method,
-                                                         with: parameters,
-                                                         onExistingResponse: currentResponse,
-                                                         success: success,
-                                                         failure: failure)
-                                    } else {
-                                        success(currentResponse)
-                                    }
-                                } else if let (reason, errorDetails) = self.buildError(fromResponse: rawResponse) {
-                                    //Figure out if we have an error and an error response
-                                    failure(MSError.responseValidationFailed(reason: reason), errorDetails)
-                                } else {
-                                    //if the request is succesful but has no response (validation for http code has passed also)
-                                    success([String: Any]())
-                                }
+        
+        let request = sessionManager.request(urlString,
+                                             method: method,
+                                             parameters: parameters,
+                                             encoding: encoding,
+                                             headers: headers).validate(statusCode: AlamoNetworkManager.validStatusCodes).responseJSON { rawResponse in
+                                                
+                                                //Print response if we have a verbose log mode
+                                                AlamoNetworkManager.logNetwork(rawResponse: rawResponse)
+                                                
+                                                //Return valid response
+                                                if let response = rawResponse.value as? [String:Any],
+                                                    rawResponse.error == nil {
+                                                    // Cached our response through URLCache
+                                                    AlamoNetworkManager.cache(response: rawResponse.response,
+                                                                              with: rawResponse.data,
+                                                                              for: rawResponse.request,
+                                                                              using: cachePolicy)
+                                                    
+                                                    //Process valid response
+                                                    self.processNextPage(response: response,
+                                                                         forURL: urlString,
+                                                                         method: method,
+                                                                         parameters: parameters,
+                                                                         onExistingResponse: aggregateResponse,
+                                                                         encoding: encoding,
+                                                                         headers: headers,
+                                                                         cachePolicy: cachePolicy,
+                                                                         success: success,
+                                                                         failure: failure)
+                                                } else if let (reason, errorDetails) = self.buildError(fromResponse: rawResponse) {
+                                                    //Figure out if we have an error and an error response
+                                                    failure(MSError.responseValidationFailed(reason: reason), errorDetails)
+                                                } else {
+                                                    //if the request is succesful but has no response (validation for http code has passed also)
+                                                    success([String: Any]())
+                                                }
+        }
+        
+        if cachePolicy.type == .forceCache,
+            let urlRequest = request.request,
+            let cachedResponse = urlRequest.cachedJSONResponse() as? [String:Any] {
+            
+            //Process valid response
+            self.processNextPage(response: cachedResponse,
+                                 forURL: urlString,
+                                 method: method,
+                                 parameters: parameters,
+                                 onExistingResponse: aggregateResponse,
+                                 encoding: encoding,
+                                 headers: headers,
+                                 cachePolicy: cachePolicy,
+                                 success: success,
+                                 failure: failure)
+            AlamoNetworkManager.log("CACHED \(request.description)")
+        } else {
+            request.resume()
+            AlamoNetworkManager.log(request.description)
         }
     }
-
+    
+    // MARK: - Response Processing
+    
+    
+    /// Process a network response
+    ///
+    /// - Parameters:
+    ///   - rawResponse: parsed response
+    ///   - method: HTTP method, default is GET
+    ///   - parameters: URL or body parameters depending on the HTTP method, default is empty
+    ///   - encoding: the defined encoding for the request
+    ///   - paginated: if the request should follow pagination, success only if all pages are completed
+    ///   - cachePolicy: specifices the policy to follow for caching responses
+    ///   - headers: custom headers that should be attached with this request
+    ///   - success: success block with a response
+    ///   - failure: failure block with an error
+    private func process(rawResponse:Any?,
+                         method: Alamofire.HTTPMethod,
+                         parameters: RequestParameters,
+                         encoding: ParameterEncoding,
+                         paginated: Bool,
+                         cachePolicy:CacheResponsePolicy,
+                         headers: CustomHTTPHeaders,
+                         success: @escaping SuccessResponseBlock,
+                         failure: @escaping ErrorResponseBlock) {
+        
+        if let response = rawResponse as? [Any] {
+            let responseDic = ["results": response]
+            success(responseDic)
+        } else if let response = rawResponse as? [String:Any] {
+            if let nextPage = response["next"] as? String,
+                paginated {
+                //call a request with the next page
+                self.getNextPage(forURL: nextPage,
+                                 method: method,
+                                 with: parameters,
+                                 onExistingResponse: response,
+                                 encoding: encoding,
+                                 headers: headers,
+                                 cachePolicy: cachePolicy,
+                                 success: success,
+                                 failure: failure)
+            } else {
+                //return inmediatly
+                success(response)
+            }
+        }
+    }
+    
+    /// Process a paginated network response
+    ///
+    /// - Parameters:
+    ///   - response: parsed response list of objects
+    ///   - urlString: next page URL
+    ///   - method: HTTP method, default is GET
+    ///   - parameters: URL or body parameters depending on the HTTP method, default is empty
+    ///   - aggregateResponse: our agregated response from previous responses
+    ///   - encoding: the defined encoding for the request
+    ///   - paginated: if the request should follow pagination, success only if all pages are completed
+    ///   - cachePolicy: specifices the policy to follow for caching responses
+    ///   - headers: custom headers that should be attached with this request
+    ///   - success: success block with a response
+    ///   - failure: failure block with an error
+    private func processNextPage(response:[String:Any],
+                                 forURL urlString: String,
+                                 method: Alamofire.HTTPMethod,
+                                 parameters: RequestParameters,
+                                 onExistingResponse aggregateResponse: [String: Any],
+                                 encoding: ParameterEncoding,
+                                 headers: CustomHTTPHeaders?,
+                                 cachePolicy:CacheResponsePolicy,
+                                 success: @escaping SuccessResponseBlock,
+                                 failure: @escaping ErrorResponseBlock) {
+        var currentResponse = aggregateResponse
+        
+        //attach new response into existing response
+        if var currentResults = currentResponse["results"] as? [[String: Any]],
+            let newResults = response["results"] as? [[String : Any]] {
+            currentResults.append(contentsOf: newResults)
+            currentResponse["results"] = currentResults
+        }
+        
+        //iterate on the next page if any
+        if let nextPage = response["next"] as? String,
+            !nextPage.isEmpty {
+            self.getNextPage(forURL: nextPage,
+                             method: method,
+                             with: parameters,
+                             onExistingResponse: currentResponse,
+                             encoding: encoding,
+                             headers: headers,
+                             cachePolicy: cachePolicy,
+                             success: success,
+                             failure: failure)
+        } else {
+            success(currentResponse)
+        }
+        
+    }
+    
+    // MARK: - Error Handling
+    
     /// Returns an ResponseFailureReason and MSErrorDetails if the rawResponse is a valid error and has an error response
     ///
     /// - Parameter rawResponse: response from the request
@@ -181,28 +325,28 @@ open class AlamoNetworkManager: NetworkManager {
         }
         else if let error = rawResponse.error as NSError?, error.code.isNetworkErrorCode {
             
-            let components = requestComponents(rawResponse.request)
+            let components = AlamoNetworkManager.requestComponents(rawResponse.request)
             let details = MSErrorDetails(errorType: "offline", message: error.localizedDescription, body: components?.body, path: components?.path)
             return (MSError.ResponseFailureReason.connectivity(code: error.code), details)
         }
         
         return nil
     }
-
+    
     /// Returns an error response from a data stream
     ///
     /// - Parameter data: data stream
     /// - Returns: a response, empty dictionary if there were issues parsing the data
     private func errorResponse(fromData data: Data?, request: URLRequest?) -> MSErrorDetails? {
         var errorResponse: MSErrorDetails? = nil
-        let components = requestComponents(request)
+        let components = AlamoNetworkManager.requestComponents(request)
         let body = components?.body
         let path = components?.path
         
         if let responseData = data,
             let responseDataString = String(data: responseData, encoding:String.Encoding.utf8),
-            let responseDictionary = self.convertToDictionary(text: responseDataString) {
-
+            let responseDictionary = AlamoNetworkManager.convertToDictionary(text: responseDataString) {
+            
             if let responseError = responseDictionary["error"] as? [String: Any],
                 let errorType = responseError["type"] as? String,
                 let message = responseError["message"] as? String {
@@ -218,7 +362,11 @@ open class AlamoNetworkManager: NetworkManager {
         return errorResponse
     }
     
-    private func requestComponents(_ request: URLRequest?) -> (path: String?, body: String?)? {
+    /// Extracts a path and a body from a URLRequest
+    ///
+    /// - Parameter request: original request
+    /// - Returns: tuple of path and body
+    private static func requestComponents(_ request: URLRequest?) -> (path: String?, body: String?)? {
         guard let request = request else { return nil }
         let path = request.url?.absoluteString
         var body:String? = nil
@@ -234,7 +382,7 @@ open class AlamoNetworkManager: NetworkManager {
     ///
     /// - Parameter text: string response
     /// - Returns: dictionary response
-    private func convertToDictionary(text: String) -> [String: Any]? {
+    private static func convertToDictionary(text: String) -> [String: Any]? {
         if let data = text.data(using: .utf8) {
             do {
                 return try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
@@ -243,5 +391,52 @@ open class AlamoNetworkManager: NetworkManager {
             }
         }
         return nil
+    }
+    
+    // MARK: - Debugging
+    
+    /// Prints a debug of a network response
+    ///
+    /// - Parameter rawResponse: response to get printed
+    private static func logNetwork(rawResponse:Any) {
+        if ServiceLocator.logLevel == .verbose {
+            print("🔵 ServiceLocator: ")
+            debugPrint(rawResponse)
+        }
+    }
+    
+    /// Print a service locator log if we have logging enabled
+    ///
+    /// - Parameter text: log to print
+    private static func log(_ text:String) {
+        //Print request if we have log mode enabled
+        if ServiceLocator.logLevel != .none {
+            print("🔵 ServiceLocator: " + text)
+        }
+    }
+    
+    // MARK: - Caching
+    
+    /// Handles caching a response based on a cache policy
+    ///
+    /// - Parameters:
+    ///   - response: the network response
+    ///   - data: response's data
+    ///   - request: original request
+    ///   - cachePolicy: cache policy
+    private static func cache(response:HTTPURLResponse?, with data:Data?, for request:URLRequest?, using cachePolicy: CacheResponsePolicy) {
+        // Cached our response through URLCache if we are force caching and the response doesn't specify a Cache-Control
+        let maxAge = 120.0
+        if cachePolicy.type == .forceCache,
+            let response = response,
+            response.isResponseCachePolicyDisabled,
+            let request = request,
+            let data = data,
+            maxAge > 0 {
+            let cachedURLResponse = CachedURLResponse(response: response,
+                                                      data: data,
+                                                      maxAge: maxAge)
+            URLCache.shared.storeCachedResponse(cachedURLResponse, for: request)
+        }
     }
 }

--- a/NetworkingServiceKit/Classes/Networking/AlamoNetworkManager.swift
+++ b/NetworkingServiceKit/Classes/Networking/AlamoNetworkManager.swift
@@ -426,16 +426,15 @@ open class AlamoNetworkManager: NetworkManager {
     ///   - cachePolicy: cache policy
     private static func cache(response:HTTPURLResponse?, with data:Data?, for request:URLRequest?, using cachePolicy: CacheResponsePolicy) {
         // Cached our response through URLCache if we are force caching and the response doesn't specify a Cache-Control
-        let maxAge = 120.0
         if cachePolicy.type == .forceCache,
             let response = response,
             response.isResponseCachePolicyDisabled,
             let request = request,
             let data = data,
-            maxAge > 0 {
+            cachePolicy.maxAge > 0 {
             let cachedURLResponse = CachedURLResponse(response: response,
                                                       data: data,
-                                                      maxAge: maxAge)
+                                                      maxAge: cachePolicy.maxAge)
             URLCache.shared.storeCachedResponse(cachedURLResponse, for: request)
         }
     }

--- a/NetworkingServiceKit/Classes/Networking/AlamoNetworkManager.swift
+++ b/NetworkingServiceKit/Classes/Networking/AlamoNetworkManager.swift
@@ -100,7 +100,7 @@ open class AlamoNetworkManager: NetworkManager {
                                                 }
         }
 
-        if cachePolicy.type == .forceCache,
+        if cachePolicy.type == .forceCacheDataElseLoad,
             let urlRequest = request.request,
             let cachedResponse = urlRequest.cachedJSONResponse() {
             //Process valid response
@@ -183,7 +183,7 @@ open class AlamoNetworkManager: NetworkManager {
                                                 }
         }
         
-        if cachePolicy.type == .forceCache,
+        if cachePolicy.type == .forceCacheDataElseLoad,
             let urlRequest = request.request,
             let cachedResponse = urlRequest.cachedJSONResponse() as? [String:Any] {
             
@@ -426,7 +426,7 @@ open class AlamoNetworkManager: NetworkManager {
     ///   - cachePolicy: cache policy
     private static func cache(response:HTTPURLResponse?, with data:Data?, for request:URLRequest?, using cachePolicy: CacheResponsePolicy) {
         // Cached our response through URLCache if we are force caching and the response doesn't specify a Cache-Control
-        if cachePolicy.type == .forceCache,
+        if cachePolicy.type.supportsForceCache,
             let response = response,
             response.isResponseCachePolicyDisabled,
             let request = request,

--- a/NetworkingServiceKit/Classes/Networking/NetworkManager.swift
+++ b/NetworkingServiceKit/Classes/Networking/NetworkManager.swift
@@ -183,8 +183,19 @@ public enum CacheResponsePolicyType : UInt {
     /// Cache based on HTTP-Header: Cache-Control
     case cacheControlBased
     
-    /// Force Cache this response
-    case forceCache
+    /// Force Cache this response, return from the cache immediatly otherwise load network
+    case forceCacheDataElseLoad
+    
+    /// Revalidates the cache, returns from network
+    case reloadRevalidatingForceCacheData
+    
+    /// If the cache policy supports force caching
+    var supportsForceCache:Bool {
+        switch self {
+        case .forceCacheDataElseLoad, .reloadRevalidatingForceCacheData: return true
+        default: return false
+        }
+    }
 }
 
 /// Describe how the cache should behave when receiving a network response

--- a/NetworkingServiceKit/Classes/Networking/NetworkManager.swift
+++ b/NetworkingServiceKit/Classes/Networking/NetworkManager.swift
@@ -176,6 +176,36 @@ public enum HTTPMethod: Int32 {
     }
 }
 
+/// Custom type of cache policy
+@objc
+public enum CacheResponsePolicyType : UInt {
+    
+    /// Cache based on HTTP-Header: Cache-Control
+    case cacheControlBased
+    
+    /// Force Cache this response
+    case forceCache
+}
+
+/// Describe how the cache should behave when receiving a network response
+@objc
+open class CacheResponsePolicy: NSObject {
+    // Cache policy type
+    let type:CacheResponsePolicyType
+    // Max age we would hold a cache, only used for forceCache, otherwise this is specified in the server response
+    let maxAge:Double
+    
+    public init(type:CacheResponsePolicyType, maxAge:Double) {
+        self.type = type
+        self.maxAge = maxAge
+    }
+    
+    /// Returns the default cache policy
+    open static var `default`:CacheResponsePolicy {
+        return CacheResponsePolicy(type:.cacheControlBased, maxAge:0)
+    }
+}
+
 /// Success/Error blocks for a NetworkManager response
 public typealias SuccessResponseBlock = ([String:Any]) -> Void
 public typealias ErrorResponseBlock = (MSError, MSErrorDetails?) -> Void
@@ -190,6 +220,7 @@ public protocol NetworkManager {
                  method: NetworkingServiceKit.HTTPMethod,
                  with parameters: RequestParameters,
                  paginated: Bool,
+                 cachePolicy:CacheResponsePolicy,
                  headers: CustomHTTPHeaders,
                  stubs: [ServiceStub],
                  success: @escaping SuccessResponseBlock,

--- a/NetworkingServiceKit/Classes/Service.swift
+++ b/NetworkingServiceKit/Classes/Service.swift
@@ -49,6 +49,7 @@ public protocol Service {
     ///   - method: HTTP method
     ///   - parameters: parameters for the request
     ///   - paginated: if we have to merge this request pagination
+    ///   - cachePolicy: specifices the policy to follow for caching responses
     ///   - headers: optional headers to include in the request
     ///   - success: success block
     ///   - failure: failure block
@@ -56,6 +57,7 @@ public protocol Service {
                  method: NetworkingServiceKit.HTTPMethod,
                  with parameters: RequestParameters,
                  paginated: Bool,
+                 cachePolicy: CacheResponsePolicy,
                  headers: CustomHTTPHeaders,
                  success: @escaping SuccessResponseBlock,
                  failure: @escaping ErrorResponseBlock)
@@ -131,6 +133,7 @@ open class AbstractBaseService: NSObject, Service {
     ///   - method: HTTP method, default is GET
     ///   - parameters: URL or body parameters depending on the HTTP method, default is empty
     ///   - paginated: if the request should follow pagination, success only if all pages are completed
+    ///   - cachePolicy: specifices the policy to follow for caching responses
     ///   - headers: custom headers that should be attached with this request
     ///   - success: success block with a response
     ///   - failure: failure block with an error
@@ -138,6 +141,7 @@ open class AbstractBaseService: NSObject, Service {
                  method: NetworkingServiceKit.HTTPMethod = .get,
                  with parameters: RequestParameters = RequestParameters(),
                  paginated: Bool = false,
+                 cachePolicy: CacheResponsePolicy = CacheResponsePolicy.default,
                  headers: CustomHTTPHeaders = CustomHTTPHeaders(),
                  success: @escaping SuccessResponseBlock,
                  failure: @escaping ErrorResponseBlock) {
@@ -145,6 +149,7 @@ open class AbstractBaseService: NSObject, Service {
                                     method: method,
                                     with: parameters,
                                     paginated: paginated,
+                                    cachePolicy: cachePolicy,
                                     headers: headers,
                                     stubs: self.stubs,
                                     success: success,

--- a/NetworkingServiceKit/Classes/Testing/StubNetworkManager.swift
+++ b/NetworkingServiceKit/Classes/Testing/StubNetworkManager.swift
@@ -25,6 +25,7 @@ open class StubNetworkManager: NetworkManager {
     ///   - method: HTTP method, default is GET
     ///   - parameters: URL or body parameters depending on the HTTP method, default is empty
     ///   - paginated: if the request should follow pagination, success only if all pages are completed
+    ///   - cachePolicy: specifices the policy to follow for caching responses (unused for stub network responses)
     ///   - headers: custom headers that should be attached with this request
     ///   - stubs: a list of stubbed cases for this request to get compare against
     ///   - success: success block with a response
@@ -33,6 +34,7 @@ open class StubNetworkManager: NetworkManager {
                  method: NetworkingServiceKit.HTTPMethod = .get,
                  with parameters: RequestParameters = RequestParameters(),
                  paginated: Bool = false,
+                 cachePolicy: CacheResponsePolicy = CacheResponsePolicy.default,
                  headers: CustomHTTPHeaders = CustomHTTPHeaders(),
                  stubs: [ServiceStub],
                  success: @escaping SuccessResponseBlock,


### PR DESCRIPTION
<!--
Thank you very much for your pull request fellow developer!
Here is a template of what we expect from you when submitting a Pull Request.
Think about this PR as a product that you are selling, give as much information as possible to make your product succesful.
-->

**Description:**
<!--
Describe what your feature is doing first in a TL:DR and also in a longer description. We encourage you to use emoticons. If possible link to more information that could relate to the PR.
-->
Usually if you are using Alamofire caching of requests is enabled by default with the default policy `URLRequest.CachePolicy.useProtocolCachePolicy` which means caching is only followed if the backend responds back with a header `Cache-Control` directing how the client cache should behave for a specific request ([more info](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control)).

If the backend doesn't support this header, you can get the same results by specifying a `CacheResponsePolicy` on a request coming from a service. Like this:

```swift
let randomService = ServiceLocator.service(forType: RandomService.self)
randomService?.request(path: "dictionary", 
          cachePolicy:CacheResponsePolicy(type: .forceCache, maxAge: 2),
          success: { response in
}, failure: { error, errorDetails in
})
```

This new force mode, works exactly like the 'Cache-Control' case,  taking advantage of URLCache, all the storage and indexing is encapsulated. The only difference is that we make sure the cache gets hit if we are force caching.

**Important files to review:**
<!--
A list of the existing files that had to be editted to make this PR work and also a list of the new classes that the reviewer should consider to focus on.
-->
- AlamoNetworkManager.swift