### PR TITLE
Custom ns error

### DIFF
--- a/NetworkingServiceKit.podspec
+++ b/NetworkingServiceKit.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'NetworkingServiceKit'
-  s.version          = '0.9.2'
+  s.version          = '0.9.3'
   s.summary          = 'A service layer of networking microservices for iOS.'
 
 # This description is used to generate tags and improve search results.

--- a/NetworkingServiceKit/Classes/Networking/NetworkManager.swift
+++ b/NetworkingServiceKit/Classes/Networking/NetworkManager.swift
@@ -165,6 +165,16 @@ public enum MSErrorType {
     }
 }
 
+extension MSError: CustomNSError {
+    public var errorCode: Int {
+        return details.code
+    }
+    
+    public var errorUserInfo: [String : Any] {
+        return [NSLocalizedDescriptionKey: details.message]
+    }
+}
+
 // Mapped Error response failures
 public extension MSErrorType.ResponseFailureReason {
 

--- a/NetworkingServiceKit/Classes/ServiceLocator.swift
+++ b/NetworkingServiceKit/Classes/ServiceLocator.swift
@@ -50,9 +50,9 @@ open class ServiceLocator: NSObject {
 
     /// Reloads token, networkManager and configuration with existing hooked services
     open class func reloadExistingServices() {
+        let serviceTypes = ServiceLocator.shared.loadedServiceTypes
         reset()
         
-        let serviceTypes = ServiceLocator.shared.loadedServiceTypes
         if let configType = APIConfiguration.apiConfigurationType,
             let authType = APIConfiguration.authConfigurationType,
             let tokenType = APITokenManager.tokenType {


### PR DESCRIPTION
MSError needs to conform to CustomNSError to not cause a crash when trying to check whether a generic Error object is an NSError. This only occurs when running in a build with optimization, i.e. release. Yes, this is silly.

Also fixes issue with reloadExistingServices actually clearing out all of the services.