### PR TITLE
Add optional description for invalidData errors

### DIFF
--- a/NetworkingServiceKit.podspec
+++ b/NetworkingServiceKit.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'NetworkingServiceKit'
-  s.version          = '0.9.4'
+  s.version          = '0.9.5'
   s.summary          = 'A service layer of networking microservices for iOS.'
 
 # This description is used to generate tags and improve search results.

--- a/NetworkingServiceKit/Classes/Networking/NetworkManager.swift
+++ b/NetworkingServiceKit/Classes/Networking/NetworkManager.swift
@@ -107,13 +107,13 @@ public enum MSErrorType {
     /// - invalidData: Catchall for expected data being missing
     /// - persistenceFailure: Core Data failure
     public enum PersistenceFailureReason {
-        case invalidData
+        case invalidData(description: String?)
         case persistenceFailure
         
         public var description: String {
             switch self {
-            case .invalidData:
-                return "Invalid Data"
+            case .invalidData(let description):
+                return description ?? "Invalid Data"
             case .persistenceFailure:
                 return "Core Data Failure"
             }
@@ -221,7 +221,11 @@ public extension MSError {
     
     /// Returns a generic error to describe Core Data problems
     static var genericPersistenceError: MSError {
-        return MSError(type: .persistenceValidation(reason: .invalidData), error: nil)
+        return MSError(type: .persistenceValidation(reason: .invalidData(description: nil)), error: nil)
+    }
+    
+    static func dataError(description: String) -> MSError {
+        return MSError(type: .persistenceValidation(reason: .invalidData(description: description)), error: nil)
     }
 }
 


### PR DESCRIPTION
The generic invalidData error has been working well as a catch-all error, but it's been popping up in areas where a little more context would be helpful. This PR allows for an optional specification of what specifically is missing without having to create a separate MSErrorDetails object.