### PR TITLE
Add support for reactive calls on StubNetworkManager

### DIFF
--- a/NetworkingServiceKit.podspec
+++ b/NetworkingServiceKit.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'NetworkingServiceKit'
-  s.version          = '1.1.0'
+  s.version          = '1.1.1'
   s.summary          = 'A service layer of networking microservices for iOS.'
 
 # This description is used to generate tags and improve search results.


### PR DESCRIPTION
<!--
Thank you very much for your pull request fellow developer!
Here is a template of what we expect from you when submitting a Pull Request.
Think about this PR as a product that you are selling, give as much information as possible to make your product succesful.
-->

**Description:**
<!--
Describe what your feature is doing first in a TL:DR and also in a longer description. We encourage you to use emoticons. If possible link to more information that could relate to the PR.
-->
Our submodes for ReactiveSwift was not accounting correctly for stubbing requests that pass through our `StubNetworkManager`. Now it does.
