### PR TITLE
Remove email from token tracking

### DIFF
--- a/Example/NetworkingServiceKit.xcodeproj/project.pbxproj
+++ b/Example/NetworkingServiceKit.xcodeproj/project.pbxproj
@@ -219,7 +219,6 @@
 				607FACCD1AFB9204008FA782 /* Frameworks */,
 				607FACCE1AFB9204008FA782 /* Resources */,
 				B879641C4BFF8B52E137D3BC /* [CP] Embed Pods Frameworks */,
-				DDE95358C64FC42AA9C1F513 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -239,7 +238,6 @@
 				607FACE21AFB9204008FA782 /* Frameworks */,
 				607FACE31AFB9204008FA782 /* Resources */,
 				30187946C7D1495C75625F46 /* [CP] Embed Pods Frameworks */,
-				D4549552A557B881B728843B /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -403,36 +401,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-NetworkingServiceKit_Example/Pods-NetworkingServiceKit_Example-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		D4549552A557B881B728843B /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-NetworkingServiceKit_Tests/Pods-NetworkingServiceKit_Tests-resources.sh\"\n";
-			showEnvVarsInLog = 0;
-		};
-		DDE95358C64FC42AA9C1F513 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "[CP] Copy Pods Resources";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-NetworkingServiceKit_Example/Pods-NetworkingServiceKit_Example-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/Example/NetworkingServiceKit/TwitterAPIToken.swift
+++ b/Example/NetworkingServiceKit/TwitterAPIToken.swift
@@ -36,9 +36,10 @@ public class TwitterAPIToken: NSObject, APIToken {
     public var authorization: String {
         return self.accessToken
     }
-
-    public static func make(from tokenResponse: [String:Any], email: String?) -> APIToken? {
-        if let tokenType = tokenResponse[TwitterAPITokenKey.tokenTypeKey.responseKey] as? String,
+    
+    public static func make(from tokenResponse: Any) -> APIToken? {
+        if let tokenResponse = tokenResponse as? [String: Any],
+            let tokenType = tokenResponse[TwitterAPITokenKey.tokenTypeKey.responseKey] as? String,
             let accessToken = tokenResponse[TwitterAPITokenKey.accessTokenKey.responseKey] as? String {
             let token = TwitterAPIToken(tokenType: tokenType, accessToken: accessToken)
             self.set(object: tokenType, for: .tokenTypeKey)

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,8 +1,8 @@
 PODS:
-  - Alamofire (4.5.1)
-  - AlamofireImage (3.3.0):
-    - Alamofire (~> 4.5)
-  - CryptoSwift (0.7.2)
+  - Alamofire (4.7.3)
+  - AlamofireImage (3.4.1):
+    - Alamofire (~> 4.7)
+  - CryptoSwift (0.12.0)
   - Mockingjay (2.0.0):
     - Mockingjay/Core (= 2.0.0)
     - Mockingjay/XCTest (= 2.0.0)
@@ -10,76 +10,85 @@ PODS:
     - URITemplate (~> 2.0)
   - Mockingjay/XCTest (2.0.0):
     - Mockingjay/Core
-  - NetworkingServiceKit (1.3.1):
-    - NetworkingServiceKit/Core (= 1.3.1)
-  - NetworkingServiceKit/Core (1.3.1):
+  - NetworkingServiceKit (1.4.0):
+    - NetworkingServiceKit/Core (= 1.4.0)
+  - NetworkingServiceKit/Core (1.4.0):
     - Alamofire
     - SwiftyJSON
-  - NetworkingServiceKit/ReactiveSwift (1.3.1):
+  - NetworkingServiceKit/ReactiveSwift (1.4.0):
     - Alamofire
     - AlamofireImage
     - CryptoSwift
     - ReactiveSwift
     - SwiftyJSON
-  - Nimble (7.0.1)
-  - Quick (1.1.0)
-  - ReactiveSwift (2.0.1):
-    - Result (~> 3.2)
-  - Result (3.2.3)
-  - SwiftyJSON (3.1.4)
+  - Nimble (7.3.1)
+  - Quick (1.3.2)
+  - ReactiveSwift (4.0.0):
+    - Result (~> 4.0)
+  - Result (4.0.0)
+  - SwiftyJSON (4.2.0)
   - URITemplate (2.1.0)
 
 DEPENDENCIES:
-  - Mockingjay (from `git@github.com:darkzlave/Mockingjay.git`, branch `master`)
+  - "Mockingjay (from `git@github.com:darkzlave/Mockingjay.git`, branch `master`)"
   - NetworkingServiceKit (from `../`)
   - NetworkingServiceKit/ReactiveSwift (from `../`)
-  - Nimble (from `git@github.com:Quick/Nimble.git`, branch `master`)
-  - Quick (from `git@github.com:Quick/Quick.git`, branch `master`)
-  - URITemplate (from `git@github.com:darkzlave/URITemplate.swift.git`, branch `master`)
+  - "Nimble (from `git@github.com:Quick/Nimble.git`, branch `master`)"
+  - "Quick (from `git@github.com:Quick/Quick.git`, branch `master`)"
+  - "URITemplate (from `git@github.com:darkzlave/URITemplate.swift.git`, branch `master`)"
+
+SPEC REPOS:
+  https://github.com/cocoapods/specs.git:
+    - Alamofire
+    - AlamofireImage
+    - CryptoSwift
+    - ReactiveSwift
+    - Result
+    - SwiftyJSON
 
 EXTERNAL SOURCES:
   Mockingjay:
     :branch: master
-    :git: git@github.com:darkzlave/Mockingjay.git
+    :git: "git@github.com:darkzlave/Mockingjay.git"
   NetworkingServiceKit:
-    :path: ../
+    :path: "../"
   Nimble:
     :branch: master
-    :git: git@github.com:Quick/Nimble.git
+    :git: "git@github.com:Quick/Nimble.git"
   Quick:
     :branch: master
-    :git: git@github.com:Quick/Quick.git
+    :git: "git@github.com:Quick/Quick.git"
   URITemplate:
     :branch: master
-    :git: git@github.com:darkzlave/URITemplate.swift.git
+    :git: "git@github.com:darkzlave/URITemplate.swift.git"
 
 CHECKOUT OPTIONS:
   Mockingjay:
     :commit: cf544670b8d95f3f53716023ca665689a05a2784
-    :git: git@github.com:darkzlave/Mockingjay.git
+    :git: "git@github.com:darkzlave/Mockingjay.git"
   Nimble:
-    :commit: a63252b16eba6cdebec4e4936388c90552165a68
-    :git: git@github.com:Quick/Nimble.git
+    :commit: c72edbbd6358090f8f1c4b6141538ebc88d167d9
+    :git: "git@github.com:Quick/Nimble.git"
   Quick:
-    :commit: 3665ae9570b682a562df847cccbb46811864676a
-    :git: git@github.com:Quick/Quick.git
+    :commit: 59e5dd8747ffbbc0d23f0c6093d93b23c61699f0
+    :git: "git@github.com:Quick/Quick.git"
   URITemplate:
     :commit: 113d21e14d462a824f0a67587c75e10bcf8bf372
-    :git: git@github.com:darkzlave/URITemplate.swift.git
+    :git: "git@github.com:darkzlave/URITemplate.swift.git"
 
 SPEC CHECKSUMS:
-  Alamofire: 2d95912bf4c34f164fdfc335872e8c312acaea4a
-  AlamofireImage: 2e784dc5d00f04903a52c1d169181469c805c3df
-  CryptoSwift: cd2158be2bf639aabc63ec804707c7137c90157c
+  Alamofire: c7287b6e5d7da964a70935e5db17046b7fde6568
+  AlamofireImage: 78d67ccbb763d87ba44b21583d2153500a195630
+  CryptoSwift: 1c07ca50843dd48bc54e6ea53d7a4dba3b645716
   Mockingjay: 95a5fbe594f963f7536d3975739df39f1366f4d1
-  NetworkingServiceKit: 6a3bcc06d78c1a056edfff6913a10bf2adf3503c
-  Nimble: 1b6670c36e5750169b9e4cc2e9cfa82a7603c69e
-  Quick: 4700beb8056662b579facd79eaca7f04fb3d48e6
-  ReactiveSwift: 60a29ff35988a964fd2bb759755cb6594de523fc
-  Result: 128640a6347e8d2ae48b142556739a2d13f90ce6
-  SwiftyJSON: c2842d878f95482ffceec5709abc3d05680c0220
+  NetworkingServiceKit: fc9ebbe1a4f73fdbc16b78b74f9006bd31a99e4c
+  Nimble: 6e4123b6d882a0f8c7f950236a3251d678cf12a2
+  Quick: 1a3fc6d2b9143276258d816c904b983a1df916a2
+  ReactiveSwift: a2bb9ace428a109e9c0209615645d9d286c8c433
+  Result: 7645bb3f50c2ce726dd0ff2fa7b6f42bbe6c3713
+  SwiftyJSON: c4bcba26dd9ec7a027fc8eade48e2c911f229e96
   URITemplate: bf971b2a5637e9fe19c64781309d1616689e4026
 
 PODFILE CHECKSUM: c094b9ea9a0105359da668dfc37aa65bd9bd332f
 
-COCOAPODS: 1.4.0
+COCOAPODS: 1.5.3

--- a/Example/Tests/APITokenTests.swift
+++ b/Example/Tests/APITokenTests.swift
@@ -21,7 +21,6 @@ class APITokenTests: QuickSpec {
         }
         
         describe("when setting up access token information") {
-            let userEmail = "email1@email.com"
             context("if we have an access token") {
                 
                 it("should return the appropiate information for the given email") {
@@ -31,7 +30,7 @@ class APITokenTests: QuickSpec {
                                         "expires_in" : 100,
                                         "scope" : "mobile"] as [String : Any]
                     APITokenManager.tokenType = TwitterAPIToken.self
-                    let apiToken = APITokenManager.store(tokenInfo: dataResponse, for: userEmail)
+                    let apiToken = APITokenManager.store(tokenInfo: dataResponse)
                     expect(apiToken).toNot(beNil())
                     
                     let accessToken = TwitterAPIToken.object(for: TwitterAPITokenKey.accessTokenKey) as! String
@@ -48,7 +47,7 @@ class APITokenTests: QuickSpec {
                                         "expires_in" : 100,
                                         "scope" : "mobile"] as [String : Any]
                     APITokenManager.tokenType = TwitterAPIToken.self
-                    let apiToken = APITokenManager.store(tokenInfo: dataResponse, for: userEmail)
+                    let apiToken = APITokenManager.store(tokenInfo: dataResponse)
                     expect(apiToken).toNot(beNil())
                     
                     ServiceLocator.set(services: [TwitterSearchService.self],
@@ -69,7 +68,7 @@ class APITokenTests: QuickSpec {
                                         "expires_in" : 100,
                                         "scope" : "mobile"] as [String : Any]
                     APITokenManager.tokenType = TwitterAPIToken.self
-                    let apiToken = APITokenManager.store(tokenInfo: dataResponse, for: userEmail)
+                    let apiToken = APITokenManager.store(tokenInfo: dataResponse)
                     expect(apiToken).toNot(beNil())
                     APITokenManager.clearAuthentication()
                     

--- a/NetworkingServiceKit.podspec
+++ b/NetworkingServiceKit.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'NetworkingServiceKit'
-  s.version          = '1.3.1'
+  s.version          = '1.4.0'
   s.summary          = 'A service layer of networking microservices for iOS.'
 
 # This description is used to generate tags and improve search results.

--- a/NetworkingServiceKit/Classes/Networking/APIToken.swift
+++ b/NetworkingServiceKit/Classes/Networking/APIToken.swift
@@ -13,7 +13,7 @@ import Foundation
 public protocol APIToken {
     var authorization: String { get }
     static func makePersistedToken() -> APIToken?
-    static func make(from tokenResponse: Any?) -> APIToken?
+    static func make(from tokenResponse: Any) -> APIToken?
     static func clearToken()
 }
 
@@ -34,7 +34,7 @@ open class APITokenManager: NSObject {
     }
 
     @discardableResult
-    public static func store(tokenInfo: Any?) -> APIToken? {
+    public static func store(tokenInfo: Any) -> APIToken? {
         if let type = APITokenManager.tokenType {
             return type.make(from: tokenInfo)
         }

--- a/NetworkingServiceKit/Classes/Networking/APIToken.swift
+++ b/NetworkingServiceKit/Classes/Networking/APIToken.swift
@@ -13,7 +13,7 @@ import Foundation
 public protocol APIToken {
     var authorization: String { get }
     static func makePersistedToken() -> APIToken?
-    static func make(from tokenResponse: [String:Any], email: String?) -> APIToken?
+    static func make(from tokenResponse: Any?) -> APIToken?
     static func clearToken()
 }
 
@@ -34,9 +34,9 @@ open class APITokenManager: NSObject {
     }
 
     @discardableResult
-    public static func store(tokenInfo: [String:Any], for email: String? = nil) -> APIToken? {
+    public static func store(tokenInfo: Any?) -> APIToken? {
         if let type = APITokenManager.tokenType {
-            return type.make(from: tokenInfo, email: email)
+            return type.make(from: tokenInfo)
         }
         return nil
     }

--- a/NetworkingServiceKit/Classes/Networking/NetworkManager.swift
+++ b/NetworkingServiceKit/Classes/Networking/NetworkManager.swift
@@ -305,7 +305,7 @@ open class CacheResponsePolicy: NSObject {
     }
     
     /// Returns the default cache policy
-    open static var `default`:CacheResponsePolicy {
+    public static var `default`:CacheResponsePolicy {
         return CacheResponsePolicy(type:.cacheControlBased, maxAge:0)
     }
 }


### PR DESCRIPTION
Simplify the interface to not require an email specification. If needed, this can be nested within the `tokenInfo` instead